### PR TITLE
[fix] 구글 지도 출력 수정 및 데이터 매직넘버 수정

### DIFF
--- a/POOKOOMIN/Assets/01.Scenes/Map.unity
+++ b/POOKOOMIN/Assets/01.Scenes/Map.unity
@@ -299,66 +299,22 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 108856605}
   m_CullTransparentMesh: 1
---- !u!1 &144797334
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 144797336}
-  - component: {fileID: 144797335}
-  m_Layer: 0
-  m_Name: GPSServices
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &144797335
+--- !u!114 &144797335 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4690940227592117680, guid: 964c75710c107054397f125f7542f52a, type: 3}
+  m_PrefabInstance: {fileID: 7524151453185262111}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 144797334}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6201261805cf16041b5c7195c463106e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <mapTileScale>k__BackingField: 1
-  <mapTileSizePixels>k__BackingField: 640
-  <mapTileZoomLevel>k__BackingField: 17
-  _isSimulation: 1
-  _simulationTarget: {fileID: 743171553}
-  _simulationStartLocation:
-    latitude: 37.4946
-    longitude: 127.0276056
-  mapOrigin:
-    latitude: 0
-    longitude: 0
-  mapCenter:
-    latitude: 0
-    longitude: 0
-  mapWorldCenter: {x: 0, y: 0, z: 0}
-  mapScale: {x: 0, y: 0}
---- !u!4 &144797336
+--- !u!4 &144797336 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+  m_PrefabInstance: {fileID: 7524151453185262111}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 144797334}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 763256113}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &181368150
 GameObject:
   m_ObjectHideFlags: 0
@@ -740,50 +696,22 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 211597749}
   m_CullTransparentMesh: 1
---- !u!1 &345250765
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 345250767}
-  - component: {fileID: 345250766}
-  m_Layer: 0
-  m_Name: MapSerivces
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &345250766
+--- !u!114 &345250766 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2877978387325156347, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+  m_PrefabInstance: {fileID: 6571538138932342227}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345250765}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4916bd81f4efc644c828cee3e743f6f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &345250767
+--- !u!4 &345250767 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+  m_PrefabInstance: {fileID: 6571538138932342227}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345250765}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 763256113}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &375158414
 GameObject:
   m_ObjectHideFlags: 0
@@ -956,7 +884,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &700063084
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1148,6 +1076,7 @@ MonoBehaviour:
   twoStepRange: 150
   threeStepRange: 200
   _googleMapTileManager: {fileID: 375158415}
+  _gpsLocationService: {fileID: 0}
 --- !u!4 &790489891
 Transform:
   m_ObjectHideFlags: 0
@@ -2311,6 +2240,124 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bb5ec727ca016624d868ca817d0bb0fa, type: 3}
+--- !u!1001 &6571538138932342227
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 763256113}
+    m_Modifications:
+    - target: {fileID: 2549101803225262356, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_Name
+      value: MapSerivces
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6353429534911923363, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3f4759ae304217a408e8ecaaded6e3db, type: 3}
+--- !u!1001 &7524151453185262111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 763256113}
+    m_Modifications:
+    - target: {fileID: 4150566172807951336, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_Name
+      value: GPSServices
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4259588830955859007, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4690940227592117680, guid: 964c75710c107054397f125f7542f52a, type: 3}
+      propertyPath: _simulationTarget
+      value: 
+      objectReference: {fileID: 743171553}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 964c75710c107054397f125f7542f52a, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/POOKOOMIN/Assets/02.Scripts/Controllers/PC.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Controllers/PC.cs
@@ -98,9 +98,9 @@ namespace FoodyGo.Controllers
 
         private void FixedUpdate()
         {
-            float x = GoogleMapUtils.LonToUnityX(_gpsLocationService.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.mapTileZoomLevel);
+            float x = GoogleMapUtils.LonToUnityX(_gpsLocationService.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.ZoomLevel);
 
-            float z = GoogleMapUtils.LatToUnityY(_gpsLocationService.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.mapTileZoomLevel);
+            float z = GoogleMapUtils.LatToUnityY(_gpsLocationService.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.ZoomLevel);
 
             transform.position = new Vector3(x, 0f, z);
 

--- a/POOKOOMIN/Assets/02.Scripts/Managers/PlacesMarkersManager.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Managers/PlacesMarkersManager.cs
@@ -61,7 +61,7 @@ namespace FoodyGo.Managers
                 PlaceMarkerController marker = Instantiate(_markerPrefab);
                 marker.RefreshPlace(place.name);
                 marker.transform.position
-                    = new Vector3(GoogleMapUtils.LonToUnityX(place.longitude, _gpsLocationService.mapCenter.longitude, _gpsLocationService.mapTileZoomLevel), 0f, GoogleMapUtils.LatToUnityY(place.latitude, _gpsLocationService.mapCenter.latitude, _gpsLocationService.mapTileZoomLevel));
+                    = new Vector3(GoogleMapUtils.LonToUnityX(place.longitude, _gpsLocationService.mapCenter.longitude, _gpsLocationService.ZoomLevel), 0f, GoogleMapUtils.LatToUnityY(place.latitude, _gpsLocationService.mapCenter.latitude, _gpsLocationService.ZoomLevel));
                 _markers.Add(marker);
             }
         }

--- a/POOKOOMIN/Assets/02.Scripts/Mapping/GoogleMapTile.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Mapping/GoogleMapTile.cs
@@ -60,5 +60,15 @@ namespace FoodyGo.Mapping
 
             _renderer.material.mainTexture = texture;
         }
+
+        private readonly int TILE_WORLD_SIZE = 100;
+        /// <summary>
+        /// Tile 영역 선으로 그리기
+        /// </summary>
+        private void OnDrawGizmos()
+        {
+            Gizmos.color = Color.blue;
+            Gizmos.DrawWireCube(transform.position, new Vector3(TILE_WORLD_SIZE, 1f, TILE_WORLD_SIZE));
+        }
     }
 }

--- a/POOKOOMIN/Assets/02.Scripts/Mapping/GoogleMapTileManager.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Mapping/GoogleMapTileManager.cs
@@ -57,10 +57,10 @@ namespace FoodyGo.Mapping
         Vector2Int CalcTileIndex(MapLocation loc)
         {
             float x = (float)GoogleMapUtils.LonToUnityX(
-                loc.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.mapTileZoomLevel);
+                loc.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.ZoomLevel);
 
             float z = (float)GoogleMapUtils.LatToUnityY(
-                loc.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.mapTileZoomLevel);
+                loc.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.ZoomLevel);
 
             return new Vector2Int(HalfFloor(x), HalfFloor(z));
         }
@@ -90,7 +90,7 @@ namespace FoodyGo.Mapping
                     tile.tileOffset = new Vector2Int(i - 1, j - 1);
                     tile.googleStaticMapService = _googleStaticMapService;
                     tile.worldCenterLocation = _gpsLocationService.mapOrigin;
-                    tile.zoomLevel = _gpsLocationService.mapTileZoomLevel;
+                    tile.zoomLevel = _gpsLocationService.ZoomLevel;
                     tile.gpsLocationService = _gpsLocationService;
                     tile.transform.position = CalcTilePosition(location)
                         + new Vector3(i - 1, 0, j - 1) * PLANE_SIZE;
@@ -110,9 +110,9 @@ namespace FoodyGo.Mapping
                 _gpsLocationService.latitude, _gpsLocationService.longitude);
 
             float dx = (float)GoogleMapUtils.LonToUnityX(
-                curLoc.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.mapTileZoomLevel);
+                curLoc.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.ZoomLevel);
             float dz = (float)GoogleMapUtils.LatToUnityY(
-                curLoc.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.mapTileZoomLevel);
+                curLoc.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.ZoomLevel);
 
             Vector2Int targetIndex = CalcTileIndex(curLoc);
             Vector2Int deltaIndex = targetIndex - _currentCenterTileIndex;

--- a/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationService.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationService.cs
@@ -8,32 +8,21 @@ namespace FoodyGo.Services.GPS
 {
     public class GPSLocationService : MonoBehaviour
     {
+        [SerializeField] private GPSLocationServiceSO _serviceData;
+
         public bool isReady { get; private set; }
-
-        [Header("Map Tile Settings")]
-        [Tooltip("맵 타일 스케일")]
-        [field: SerializeField]
-        public int mapTileScale { get; private set; } = 1;
-
-        [Tooltip("맵 타일 크기 (픽셀)")]
-        [field: SerializeField]
-        public int mapTileSizePixels { get; private set; } = 640;
-
-        [Tooltip("맵 타일 Zoom 레벨 (1 ~ 20)")]
-        [Range(1, 20)]
-        [field: SerializeField]
-        public int mapTileZoomLevel { get; private set; } = 15;
 
         [Header("Simulation Settings (Editor Only)")]
         [SerializeField] bool _isSimulation;
         [SerializeField] Transform _simulationTarget;
-        [SerializeField] MapLocation _simulationStartLocation = new MapLocation(37.4946, 127.0276056);
 
         public double latitude { get; private set; }
         public double longitude { get; private set; }
         public double altitude { get; private set; }
         public float accuracy { get; private set; }
         public double timeStamp { get; private set; }
+
+        public int ZoomLevel => _serviceData.mapTileZoomLevel;
 
         public event Action onMapRedraw;
 
@@ -49,7 +38,8 @@ namespace FoodyGo.Services.GPS
 #if UNITY_EDITOR
             SimulatedLocationProvider simulatedLocationProvider = gameObject.AddComponent<SimulatedLocationProvider>();
             simulatedLocationProvider.target = _simulationTarget;
-            simulatedLocationProvider.startLocation = _simulationStartLocation;
+            simulatedLocationProvider.zoomLevel = _serviceData.mapTileZoomLevel;
+            simulatedLocationProvider.startLocation = _serviceData.simulationStartLocation;
             _locationProvider = simulatedLocationProvider;
             timeStamp = Epoch.Now;
 #else

--- a/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationServiceSO.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationServiceSO.cs
@@ -1,0 +1,28 @@
+using FoodyGo.Mapping;
+using UnityEngine;
+
+[CreateAssetMenu(menuName ="Google/GPSLocationService", fileName = "GPSLocationService")]
+public class GPSLocationServiceSO : ScriptableObject
+{
+    [Header("Map Tile Data")]
+    [Tooltip("맵 타일 스케일")]
+    [field: SerializeField]
+    public int mapTileScale { get; private set; } = 1;
+
+    [Tooltip("맵 타일 크기 (픽셀)")]
+    [field: SerializeField]
+    public int mapTileSizePixels { get; private set; } = 640;
+    
+    [Tooltip("맵 타일 Zoom 레벨 (1 ~ 20)")]
+    [Range(1, 20)]
+    [field: SerializeField]
+    public int mapTileZoomLevel { get; private set; } = 15;
+
+    [Space(20)]
+#if UNITY_EDITOR
+    [Header("Simulated")]
+    [Tooltip("시뮬레이션 시 시작 위치")] //@tk : Default : 강남 비트 건물 좌표
+    public MapLocation simulationStartLocation = new MapLocation(37.4946, 127.0276056);
+
+#endif
+}

--- a/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationServiceSO.cs.meta
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GPS/GPSLocationServiceSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dce7f20720d49c147a0cbd09594be13e

--- a/POOKOOMIN/Assets/02.Scripts/Services/GPS/SimulatedLocationProvider.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GPS/SimulatedLocationProvider.cs
@@ -10,6 +10,7 @@ namespace FoodyGo.Services.GPS
     public class SimulatedLocationProvider : MonoBehaviour, ILocationProvider
     {
         public Transform target { get; set; }
+        public int zoomLevel { get; set;}
 
         public MapLocation startLocation { get; set; }
 
@@ -22,7 +23,6 @@ namespace FoodyGo.Services.GPS
         public bool isRunning { get; private set; }
 
         public event Action<double, double, double, float, double> onLocationUpdated;
-
 
         private double _metersPerDegreeLatitude = 111320; // 위도 1도당 약 111.32km
         private float _updateLocationInterval = 0.1f; // 갱신 간격
@@ -75,8 +75,8 @@ namespace FoodyGo.Services.GPS
 
             Vector3 currentPosition = target.position;
 
-            latitude = GoogleMapUtils.UnityYToLat(currentPosition.z, startLocation.latitude, 18);
-            longitude = GoogleMapUtils.UnityXToLon(currentPosition.x, startLocation.longitude, 18);
+            latitude = GoogleMapUtils.UnityYToLat(currentPosition.z, startLocation.latitude, zoomLevel);
+            longitude = GoogleMapUtils.UnityXToLon(currentPosition.x, startLocation.longitude, zoomLevel);
 
             onLocationUpdated?.Invoke(
                 latitude,

--- a/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapService.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapService.cs
@@ -7,10 +7,9 @@ namespace FoodyGo.Services.GoogleMaps
 {
     public class GoogleStaticMapService : MonoBehaviour
     {
-        private const string BASE_URL = "https://maps.googleapis.com/maps/api/staticmap?";
-        private const string API_KEY = "AIzaSyDqYVb-C0TTNAtDfewlZKnMmqYql9nLDss";
-        private Texture2D _cachedTexture;
+        [SerializeField] private GoogleStaticMapServiceSO _serviceData;
 
+        private Texture2D _cachedTexture;
 
         public void LoadMap(double latitude, double longitude, float zoom, Vector2 size, Action<Texture2D> onComplete)
         {
@@ -20,11 +19,11 @@ namespace FoodyGo.Services.GoogleMaps
         IEnumerator C_LoadMap(double latitude, double longitude, float zoom, Vector2 size, Action<Texture2D> onComplete)
         {
             string url =
-                BASE_URL +
+                _serviceData.BASE_URL +
                 "center=" + latitude + "," + longitude +
                 "&zoom=" + zoom +
                 "&size=" + size.x + "x" + size.y +
-                "&key=" + API_KEY;
+                "&key=" + _serviceData.API_KEY;
 
             Debug.Log($"[{nameof(GoogleStaticMapService)}] : Request map texture ... {url}");
 

--- a/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapServiceSO.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapServiceSO.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Google/GoogleStaticMapService", fileName = "GoogleStaticMapService")]
+public class GoogleStaticMapServiceSO : ScriptableObject
+{
+    public string BASE_URL = "https://maps.googleapis.com/maps/api/staticmap?";
+    public string API_KEY = "AIzaSyDqYVb-C0TTNAtDfewlZKnMmqYql9nLDss";
+}

--- a/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapServiceSO.cs.meta
+++ b/POOKOOMIN/Assets/02.Scripts/Services/GoogleMaps/GoogleStaticMapServiceSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffe7c8f5f97ef2c4283c5fa8c07e2dd3

--- a/POOKOOMIN/Assets/02.Scripts/Services/NPCs/MonsterService.cs
+++ b/POOKOOMIN/Assets/02.Scripts/Services/NPCs/MonsterService.cs
@@ -50,10 +50,10 @@ namespace FoodyGo.Services
                 {
                     var newPosition = new Vector3(
                         (float)GoogleMapUtils.LonToUnityX
-                        (m.location.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.mapTileZoomLevel),
+                        (m.location.longitude, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.ZoomLevel),
                         0,
                         (float)GoogleMapUtils.LatToUnityY
-                        (m.location.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.mapTileZoomLevel));
+                        (m.location.latitude, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.ZoomLevel));
                     m.gameObject.transform.position = newPosition;
                 }
             }
@@ -164,10 +164,10 @@ namespace FoodyGo.Services
             var lat = monster.location.latitude;
             var position = new Vector3(
                         (float)GoogleMapUtils.LonToUnityX
-                        (lon, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.mapTileZoomLevel),
+                        (lon, _gpsLocationService.mapOrigin.longitude, _gpsLocationService.ZoomLevel),
                         0,
                         (float)GoogleMapUtils.LatToUnityY
-                        (lat, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.mapTileZoomLevel));
+                        (lat, _gpsLocationService.mapOrigin.latitude, _gpsLocationService.ZoomLevel));
             var rotation = Quaternion.AngleAxis(Random.Range(0, 360), Vector3.up);
             monster.gameObject = (GameObject)Instantiate(monsterPrefab, position, rotation);
         }

--- a/POOKOOMIN/Assets/Resources/Service.meta
+++ b/POOKOOMIN/Assets/Resources/Service.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c57f9e24ad282574189fab6f865b7ac1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POOKOOMIN/Assets/Resources/Service/GPSServices.prefab
+++ b/POOKOOMIN/Assets/Resources/Service/GPSServices.prefab
@@ -1,0 +1,62 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4150566172807951336
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4259588830955859007}
+  - component: {fileID: 4690940227592117680}
+  m_Layer: 0
+  m_Name: GPSServices
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4259588830955859007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4150566172807951336}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4690940227592117680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4150566172807951336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6201261805cf16041b5c7195c463106e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _serviceData: {fileID: 11400000, guid: 069cffd257dd3d34eaf2fa7db8f21afd, type: 2}
+  <mapTileScale>k__BackingField: 1
+  <mapTileSizePixels>k__BackingField: 640
+  <mapTileZoomLevel>k__BackingField: 15
+  _isSimulation: 1
+  _simulationTarget: {fileID: 0}
+  _simulationStartLocation:
+    latitude: 37.4946
+    longitude: 127.0276056
+  mapOrigin:
+    latitude: 0
+    longitude: 0
+  mapCenter:
+    latitude: 0
+    longitude: 0
+  mapScale: {x: 0, y: 0}

--- a/POOKOOMIN/Assets/Resources/Service/GPSServices.prefab.meta
+++ b/POOKOOMIN/Assets/Resources/Service/GPSServices.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 964c75710c107054397f125f7542f52a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POOKOOMIN/Assets/Resources/Service/MapSerivces.prefab
+++ b/POOKOOMIN/Assets/Resources/Service/MapSerivces.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2549101803225262356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6353429534911923363}
+  - component: {fileID: 2877978387325156347}
+  m_Layer: 0
+  m_Name: MapSerivces
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6353429534911923363
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2549101803225262356}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2877978387325156347
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2549101803225262356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4916bd81f4efc644c828cee3e743f6f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _serviceData: {fileID: 11400000, guid: 21dd3852718234b40895cd43c4b53c59, type: 2}

--- a/POOKOOMIN/Assets/Resources/Service/MapSerivces.prefab.meta
+++ b/POOKOOMIN/Assets/Resources/Service/MapSerivces.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3f4759ae304217a408e8ecaaded6e3db
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POOKOOMIN/Assets/SO.meta
+++ b/POOKOOMIN/Assets/SO.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13f27b62cf21d544da4f5dd7115b99da
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POOKOOMIN/Assets/SO/GPSLocationService.asset
+++ b/POOKOOMIN/Assets/SO/GPSLocationService.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dce7f20720d49c147a0cbd09594be13e, type: 3}
+  m_Name: GPSLocationService
+  m_EditorClassIdentifier: 
+  <mapTileScale>k__BackingField: 1
+  <mapTileSizePixels>k__BackingField: 640
+  <mapTileZoomLevel>k__BackingField: 15
+  _simulationStartLocation:
+    latitude: 37.4946
+    longitude: 127.0276056

--- a/POOKOOMIN/Assets/SO/GPSLocationService.asset.meta
+++ b/POOKOOMIN/Assets/SO/GPSLocationService.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 069cffd257dd3d34eaf2fa7db8f21afd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/POOKOOMIN/Assets/SO/GoogleStaticMapService.asset
+++ b/POOKOOMIN/Assets/SO/GoogleStaticMapService.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ffe7c8f5f97ef2c4283c5fa8c07e2dd3, type: 3}
+  m_Name: GoogleStaticMapService
+  m_EditorClassIdentifier: 

--- a/POOKOOMIN/Assets/SO/GoogleStaticMapService.asset.meta
+++ b/POOKOOMIN/Assets/SO/GoogleStaticMapService.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 21dd3852718234b40895cd43c4b53c59
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #4

## 📝작업 내용

> 구글 맵 지도 출력 오류 수정 : 사유 zoomLevel 하드 코딩되어서, 값이 다 다르게 설정되었음.
> googleGPSLocationService의 zoomLevel로 데이터 통일되도록 수정
> googleGPSLocationService, GoogleStaticMap 스크립터블 오브젝트로 데이터 수정 가능하게 함.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fb75fdb0-f5fd-4793-8499-3a68cb78a40f)
![image](https://github.com/user-attachments/assets/0485cc0b-9d3a-44c6-883f-508b399b9517)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?